### PR TITLE
chore: change Java version from Java 11 to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <spring.version>5.3.24</spring.version>
         <lombok.version>1.18.24</lombok.version>
         <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
BREAKING CHANGE: minimal version of Java supported is Java 17